### PR TITLE
Improve parameterised unit tests

### DIFF
--- a/tests/unit_tests/src/hashing_tests.ads
+++ b/tests/unit_tests/src/hashing_tests.ads
@@ -25,37 +25,11 @@ package Hashing_Tests is
       overriding
       procedure Set_Up (T : in out Test);
 
-      ------------------------------
-      -- Multi-Part Message Tests --
-      ------------------------------
-
-      --  These tests verify that a multi-part hashing operation with varying
-      --  part sizes produces the same result as the equivalent single-part
-      --  operation.
-
-      procedure Test_Multi_Part_1 (T : in out Test);
-      procedure Test_Multi_Part_2 (T : in out Test);
-      procedure Test_Multi_Part_31 (T : in out Test);
-      procedure Test_Multi_Part_32 (T : in out Test);
-      procedure Test_Multi_Part_33 (T : in out Test);
-      procedure Test_Multi_Part_63 (T : in out Test);
-      procedure Test_Multi_Part_64 (T : in out Test);
-      procedure Test_Multi_Part_65 (T : in out Test);
-      procedure Test_Multi_Part_127 (T : in out Test);
-      procedure Test_Multi_Part_128 (T : in out Test);
-      procedure Test_Multi_Part_129 (T : in out Test);
-
-      -----------------------
-      -- Hash Verify Tests --
-      -----------------------
-
+      procedure Test_Multi_Part (T : in out Test);
       procedure Test_Verify_Valid_Hash (T : in out Test);
-      procedure Test_Verify_Invalid_First_Byte (T : in out Test);
-      procedure Test_Verify_Invalid_Last_Byte (T : in out Test);
-
+      procedure Test_Verify_Invalid_Hash (T : in out Test);
       procedure Test_Finish_Verify_Valid_Hash (T : in out Test);
-      procedure Test_Finish_Verify_Invalid_First_Byte (T : in out Test);
-      procedure Test_Finish_Verify_Invalid_Last_Byte (T : in out Test);
+      procedure Test_Finish_Verify_Invalid_Hash (T : in out Test);
 
       procedure Add_To_Suite (S : in out Test_Suite'Class);
 

--- a/tests/unit_tests/src/hkdf_tests.adb
+++ b/tests/unit_tests/src/hkdf_tests.adb
@@ -9,9 +9,12 @@ with Tux.Types;
 
 package body HKDF_Tests is
 
-   ----------------------------
+   --------------------
    -- Test_Empty_OKM --
-   ----------------------------
+   --------------------
+
+   --  This test verifies that HKDF executes without errors in the case where
+   --  the output OKM buffer is an empty array (OKM'Length = 0).
 
    procedure Test_Empty_OKM (T : in out Test) is
       OKM : Tux.Types.Byte_Array (1 .. 0);

--- a/tests/unit_tests/src/hmac_tests.ads
+++ b/tests/unit_tests/src/hmac_tests.ads
@@ -23,37 +23,11 @@ package HMAC_Tests is
       overriding
       procedure Set_Up (T : in out Test);
 
-      ------------------------------
-      -- Multi-Part Message Tests --
-      ------------------------------
-
-      --  These tests verify that a multi-part hashing operation with varying
-      --  part sizes produces the same result as the equivalent single-part
-      --  operation.
-
-      procedure Test_Multi_Part_1 (T : in out Test);
-      procedure Test_Multi_Part_2 (T : in out Test);
-      procedure Test_Multi_Part_31 (T : in out Test);
-      procedure Test_Multi_Part_32 (T : in out Test);
-      procedure Test_Multi_Part_33 (T : in out Test);
-      procedure Test_Multi_Part_63 (T : in out Test);
-      procedure Test_Multi_Part_64 (T : in out Test);
-      procedure Test_Multi_Part_65 (T : in out Test);
-      procedure Test_Multi_Part_127 (T : in out Test);
-      procedure Test_Multi_Part_128 (T : in out Test);
-      procedure Test_Multi_Part_129 (T : in out Test);
-
-      -----------------------
-      -- Hash Verify Tests --
-      -----------------------
-
+      procedure Test_Multi_Part (T : in out Test);
       procedure Test_Verify_Valid_HMAC (T : in out Test);
-      procedure Test_Verify_Invalid_First_Byte (T : in out Test);
-      procedure Test_Verify_Invalid_Last_Byte (T : in out Test);
-
+      procedure Test_Verify_Invalid_HMAC (T : in out Test);
       procedure Test_Finish_And_Verify_Valid_HMAC (T : in out Test);
-      procedure Test_Finish_And_Verify_Invalid_First_Byte (T : in out Test);
-      procedure Test_Finish_And_Verify_Invalid_Last_Byte (T : in out Test);
+      procedure Test_Finish_And_Verify_Invalid_HMAC (T : in out Test);
 
       procedure Add_To_Suite (S : in out Test_Suite'Class);
 

--- a/tests/unit_tests/src/xof_tests.adb
+++ b/tests/unit_tests/src/xof_tests.adb
@@ -8,11 +8,11 @@ with Interfaces;       use Interfaces;
 
 package body XOF_Tests is
 
-   ---------------------
-   -- Multi_Part_Test --
-   ---------------------
+   ---------------------------
+   -- Multi_Part_Input_Test --
+   ---------------------------
 
-   procedure Multi_Part_Test
+   procedure Multi_Part_Input_Test
      (Buffer      : Tux.Types.Byte_Array;
       Algorithm   : Tux.XOF.Algorithm_Kind;
       Part_Length : Positive)
@@ -45,9 +45,35 @@ package body XOF_Tests is
       end loop;
 
       Tux.XOF.Update (Ctx, Buffer (Buffer'First + Offset .. Buffer'Last));
+      Tux.XOF.Extract (Ctx, Hash);
 
-      Offset    := 0;
-      Remaining := Hash'Length;
+      Assert (Hash = Reference_Hash,
+              "Multi-part hash does not match single-part hash");
+   end Multi_Part_Input_Test;
+
+   ----------------------------
+   -- Multi_Part_Output_Test --
+   ----------------------------
+
+   procedure Multi_Part_Output_Test
+     (Hash           : in out Tux.Types.Byte_Array;
+      Reference_Hash : in out Tux.Types.Byte_Array;
+      Algorithm      :        Tux.XOF.Algorithm_Kind;
+      Part_Length    :        Positive)
+   is
+      use type Tux.Types.Byte_Array;
+
+      Ctx : Tux.XOF.Context (Algorithm);
+
+      Offset    : Natural := 0;
+      Remaining : Natural := Hash'Length;
+      Pos       : Tux.Types.Index_Number;
+
+   begin
+      Tux.XOF.Compute_Digest
+        (Algorithm, Tux.Types.Empty_Byte_Array, Reference_Hash);
+
+      Tux.XOF.Initialize (Ctx);
 
       while Remaining >= Part_Length loop
          pragma Loop_Invariant (Offset + Remaining = Hash'Length);
@@ -60,9 +86,13 @@ package body XOF_Tests is
          Remaining := Remaining - Part_Length;
       end loop;
 
+      if Remaining > 0 then
+         Tux.XOF.Extract (Ctx, Hash (Hash'First + Offset .. Hash'Last));
+      end if;
+
       Assert (Hash = Reference_Hash,
               "Multi-part hash does not match single-part hash");
-   end Multi_Part_Test;
+   end Multi_Part_Output_Test;
 
    ----------------------------------
    -- Generic_XOF_Tests (body) --
@@ -82,68 +112,47 @@ package body XOF_Tests is
          end loop;
       end Set_Up;
 
-      ------------------------------
-      -- Multi-part Message Tests --
-      ------------------------------
+      ---------------------------
+      -- Test_Multi_Part_Input --
+      ---------------------------
 
-      procedure Test_Multi_Part_1 (T : in out Test) is
-      begin
-         Multi_Part_Test (T.Buffer, Algorithm, 1);
-      end Test_Multi_Part_1;
+      --  This test verifies that processing a large input message in
+      --  differently sized parts produces the same hash as processing the
+      --  entire message in a single part.
 
-      procedure Test_Multi_Part_2 (T : in out Test) is
+      procedure Test_Multi_Part_Input (T : in out Test) is
       begin
-         Multi_Part_Test (T.Buffer, Algorithm, 2);
-      end Test_Multi_Part_2;
+         for Part_Length in Tux.Types.Byte_Count range 1 .. 256 loop
+            Multi_Part_Input_Test (T.Buffer, Algorithm, Part_Length);
+         end loop;
+      end Test_Multi_Part_Input;
 
-      procedure Test_Multi_Part_31 (T : in out Test) is
-      begin
-         Multi_Part_Test (T.Buffer, Algorithm, 31);
-      end Test_Multi_Part_31;
+      ----------------------------
+      -- Test_Multi_Part_Output --
+      ----------------------------
 
-      procedure Test_Multi_Part_32 (T : in out Test) is
-      begin
-         Multi_Part_Test (T.Buffer, Algorithm, 32);
-      end Test_Multi_Part_32;
+      --  This test verifies that extracting a large multi-part hash in
+      --  differently sized parts produces the same hash as getting the output
+      --  as a single part.
 
-      procedure Test_Multi_Part_33 (T : in out Test) is
+      procedure Test_Multi_Part_Output (T : in out Test) is
+         HLen : constant Tux.Types.Byte_Count := T.Buffer'Length / 2;
       begin
-         Multi_Part_Test (T.Buffer, Algorithm, 33);
-      end Test_Multi_Part_33;
-
-      procedure Test_Multi_Part_63 (T : in out Test) is
-      begin
-         Multi_Part_Test (T.Buffer, Algorithm, 63);
-      end Test_Multi_Part_63;
-
-      procedure Test_Multi_Part_64 (T : in out Test) is
-      begin
-         Multi_Part_Test (T.Buffer, Algorithm, 64);
-      end Test_Multi_Part_64;
-
-      procedure Test_Multi_Part_65 (T : in out Test) is
-      begin
-         Multi_Part_Test (T.Buffer, Algorithm, 65);
-      end Test_Multi_Part_65;
-
-      procedure Test_Multi_Part_127 (T : in out Test) is
-      begin
-         Multi_Part_Test (T.Buffer, Algorithm, 127);
-      end Test_Multi_Part_127;
-
-      procedure Test_Multi_Part_128 (T : in out Test) is
-      begin
-         Multi_Part_Test (T.Buffer, Algorithm, 128);
-      end Test_Multi_Part_128;
-
-      procedure Test_Multi_Part_129 (T : in out Test) is
-      begin
-         Multi_Part_Test (T.Buffer, Algorithm, 129);
-      end Test_Multi_Part_129;
+         for Part_Length in Tux.Types.Byte_Count range 1 .. 256 loop
+            Multi_Part_Output_Test
+              (Hash           => T.Buffer (1 .. HLen),
+               Reference_Hash => T.Buffer (HLen + 1 .. T.Buffer'Last),
+               Algorithm      => Algorithm,
+               Part_Length    => Part_Length);
+         end loop;
+      end Test_Multi_Part_Output;
 
       ----------------------------
       -- Test_Verify_Valid_Hash --
       ----------------------------
+
+      --  This test verifies that the Verify_Digest function returns True when
+      --  presented with a valid hash.
 
       procedure Test_Verify_Valid_Hash (T : in out Test) is
          HLen  : constant Tux.XOF.Block_Length_Number :=
@@ -157,49 +166,50 @@ package body XOF_Tests is
          Assert (Valid, "Hash verify failed");
       end Test_Verify_Valid_Hash;
 
-      ------------------------------------
-      -- Test_Verify_Invalid_First_Byte --
-      ------------------------------------
+      ------------------------------
+      -- Test_Verify_Invalid_Hash --
+      ------------------------------
 
-      procedure Test_Verify_Invalid_First_Byte (T : in out Test) is
+      --  This test verifies that Verify_Digest returns False when presented
+      --  with an invalid hash.
+      --
+      --  The test is repeated for all possible 1-bit errors in the hash.
+
+      procedure Test_Verify_Invalid_Hash (T : in out Test) is
          HLen  : constant Tux.XOF.Block_Length_Number :=
                    Tux.XOF.Block_Length (Algorithm);
-         Hash  : Tux.Types.Byte_Array (1 .. HLen);
-         Valid : Boolean;
+
+         Valid_Hash   : Tux.Types.Byte_Array (1 .. HLen);
+         Invalid_Hash : Tux.Types.Byte_Array (1 .. HLen);
+         Valid        : Boolean;
 
       begin
-         Tux.XOF.Compute_Digest (Algorithm, T.Buffer, Hash);
+         Tux.XOF.Compute_Digest (Algorithm, T.Buffer, Valid_Hash);
 
-         --  Corrupt a bit in the first byte
-         Hash (Hash'First) := Hash (Hash'First) xor 1;
+         for Byte_Idx in Tux.Types.Byte_Count range 1 .. HLen loop
+            for Bit_Idx in Natural range 0 .. 7 loop
 
-         Valid := Tux.XOF.Verify_Digest (Algorithm, T.Buffer, Hash);
-         Assert (not Valid, "Invalid hash not detected");
-      end Test_Verify_Invalid_First_Byte;
+               Invalid_Hash := Valid_Hash;
 
-      -----------------------------------
-      -- Test_Verify_Invalid_Last_Byte --
-      -----------------------------------
+               Invalid_Hash (Byte_Idx) :=
+                 Invalid_Hash (Byte_Idx) xor Shift_Left (1, Bit_Idx);
 
-      procedure Test_Verify_Invalid_Last_Byte (T : in out Test) is
-         HLen  : constant Tux.XOF.Block_Length_Number :=
-                   Tux.XOF.Block_Length (Algorithm);
-         Hash  : Tux.Types.Byte_Array (1 .. HLen);
-         Valid : Boolean;
+               Valid := Tux.XOF.Verify_Digest
+                          (Algorithm, T.Buffer, Invalid_Hash);
 
-      begin
-         Tux.XOF.Compute_Digest (Algorithm, T.Buffer, Hash);
-
-         --  Corrupt a bit in the last byte
-         Hash (Hash'Last) := Hash (Hash'Last) xor 2#1000_0000#;
-
-         Valid := Tux.XOF.Verify_Digest (Algorithm, T.Buffer, Hash);
-         Assert (not Valid, "Invalid hash not detected");
-      end Test_Verify_Invalid_Last_Byte;
+               Assert (not Valid,
+                       "Invalid hash not detected when bit" & Bit_Idx'Image &
+                       " in byte" & Byte_Idx'Image & " is corrupted");
+            end loop;
+         end loop;
+      end Test_Verify_Invalid_Hash;
 
       -----------------------------------
       -- Test_Finish_Verify_Valid_Hash --
       -----------------------------------
+
+      --  This test verifies that the Extract_And_Verify function returns True
+      --  when presented with a valid hash.
 
       procedure Test_Finish_Verify_Valid_Hash (T : in out Test) is
          HLen  : constant Tux.XOF.Block_Length_Number :=
@@ -218,53 +228,45 @@ package body XOF_Tests is
          Assert (Valid, "Hash verify failed");
       end Test_Finish_Verify_Valid_Hash;
 
-      -------------------------------------------
-      -- Test_Finish_Verify_Invalid_First_Byte --
-      -------------------------------------------
+      -------------------------------------
+      -- Test_Finish_Verify_Invalid_Hash --
+      -------------------------------------
 
-      procedure Test_Finish_Verify_Invalid_First_Byte (T : in out Test) is
+      --  This test verifies that Extract_And_Verify outputs False when
+      --  presented with an invalid hash.
+      --
+      --  The test is repeated for all possible 1-bit errors in the hash.
+
+      procedure Test_Finish_Verify_Invalid_Hash (T : in out Test) is
          HLen  : constant Tux.XOF.Block_Length_Number :=
                    Tux.XOF.Block_Length (Algorithm);
-         Hash  : Tux.Types.Byte_Array (1 .. HLen);
-         Ctx   : Tux.XOF.Context (Algorithm);
-         Valid : Boolean;
+
+         Valid_Hash   : Tux.Types.Byte_Array (1 .. HLen);
+         Invalid_Hash : Tux.Types.Byte_Array (1 .. HLen);
+         Ctx          : Tux.XOF.Context (Algorithm);
+         Valid        : Boolean;
 
       begin
-         Tux.XOF.Compute_Digest (Algorithm, T.Buffer, Hash);
+         Tux.XOF.Compute_Digest (Algorithm, T.Buffer, Valid_Hash);
 
-         --  Corrupt a bit in the first byte
-         Hash (Hash'First) := Hash (Hash'First) xor 1;
+         for Byte_Idx in Tux.Types.Byte_Count range 1 .. HLen loop
+            for Bit_Idx in Natural range 0 .. 7 loop
 
-         Tux.XOF.Initialize (Ctx);
-         Tux.XOF.Update (Ctx, T.Buffer);
-         Tux.XOF.Extract_And_Verify (Ctx, Hash, Valid);
+               Invalid_Hash := Valid_Hash;
 
-         Assert (not Valid, "Invalid hash not detected");
-      end Test_Finish_Verify_Invalid_First_Byte;
+               Invalid_Hash (Byte_Idx) :=
+                 Invalid_Hash (Byte_Idx) xor Shift_Left (1, Bit_Idx);
 
-      ------------------------------------------
-      -- Test_Finish_Verify_Invalid_Last_Byte --
-      ------------------------------------------
+               Tux.XOF.Initialize (Ctx);
+               Tux.XOF.Update (Ctx, T.Buffer);
+               Tux.XOF.Extract_And_Verify (Ctx, Invalid_Hash, Valid);
 
-      procedure Test_Finish_Verify_Invalid_Last_Byte (T : in out Test) is
-         HLen  : constant Tux.XOF.Block_Length_Number :=
-                   Tux.XOF.Block_Length (Algorithm);
-         Hash  : Tux.Types.Byte_Array (1 .. HLen);
-         Ctx   : Tux.XOF.Context (Algorithm);
-         Valid : Boolean;
-
-      begin
-         Tux.XOF.Compute_Digest (Algorithm, T.Buffer, Hash);
-
-         --  Corrupt a bit in the last byte
-         Hash (Hash'Last) := Hash (Hash'Last) xor 2#1000_0000#;
-
-         Tux.XOF.Initialize (Ctx);
-         Tux.XOF.Update (Ctx, T.Buffer);
-         Tux.XOF.Extract_And_Verify (Ctx, Hash, Valid);
-
-         Assert (not Valid, "Invalid hash not detected");
-      end Test_Finish_Verify_Invalid_Last_Byte;
+               Assert (not Valid,
+                       "Invalid hash not detected when bit" & Bit_Idx'Image &
+                       " in byte" & Byte_Idx'Image & " is corrupted");
+            end loop;
+         end loop;
+      end Test_Finish_Verify_Invalid_Hash;
 
       ------------------
       -- Add_To_Suite --
@@ -277,62 +279,20 @@ package body XOF_Tests is
          if Algorithm in Tux.XOF.Enabled_Algorithm_Kind then
             S.Add_Test
               (Caller.Create
-                 (Name & " multi-part test (1 byte parts)",
-                  Test_Multi_Part_1'Access));
+                 (Name & " multi-part input test",
+                  Test_Multi_Part_Input'Access));
             S.Add_Test
               (Caller.Create
-                 (Name & " multi-part test (2 byte parts)",
-                  Test_Multi_Part_2'Access));
-            S.Add_Test
-              (Caller.Create
-                 (Name & " multi-part test (31 byte parts)",
-                  Test_Multi_Part_31'Access));
-            S.Add_Test
-              (Caller.Create
-                 (Name & " multi-part test (32 byte parts)",
-                  Test_Multi_Part_32'Access));
-            S.Add_Test
-              (Caller.Create
-                 (Name & " multi-part test (33 byte parts)",
-                  Test_Multi_Part_33'Access));
-            S.Add_Test
-              (Caller.Create
-                 (Name & " multi-part test (63 byte parts)",
-                  Test_Multi_Part_63'Access));
-            S.Add_Test
-              (Caller.Create
-                 (Name & " multi-part test (64 byte parts)",
-                  Test_Multi_Part_64'Access));
-            S.Add_Test
-              (Caller.Create
-                 (Name & " multi-part test (65 byte parts)",
-                  Test_Multi_Part_65'Access));
-            S.Add_Test
-              (Caller.Create
-                 (Name & " multi-part test (127 byte parts)",
-                  Test_Multi_Part_127'Access));
-            S.Add_Test
-              (Caller.Create
-                 (Name & " multi-part test (128 byte parts)",
-                  Test_Multi_Part_128'Access));
-            S.Add_Test
-              (Caller.Create
-                 (Name & " multi-part test (129 byte parts)",
-                  Test_Multi_Part_129'Access));
-
+                 (Name & " multi-part output test",
+                  Test_Multi_Part_Output'Access));
             S.Add_Test
               (Caller.Create
                  (Name & " test single-part hash verify - valid hash",
                   Test_Verify_Valid_Hash'Access));
             S.Add_Test
               (Caller.Create
-                 (Name & " test single-part hash verify - byte corrupted",
-                  Test_Verify_Invalid_First_Byte'Access));
-            S.Add_Test
-              (Caller.Create
-                 (Name & " test single-part hash verify - last byte corrupted",
-                  Test_Verify_Invalid_Last_Byte'Access));
-
+                 (Name & " test single-part hash verify - invalid hash",
+                  Test_Verify_Invalid_Hash'Access));
             S.Add_Test
               (Caller.Create
                  (Name &
@@ -341,13 +301,8 @@ package body XOF_Tests is
             S.Add_Test
               (Caller.Create
                  (Name & " test multi-part hash finish and verify - "
-                    & "first byte corrupted",
-                  Test_Finish_Verify_Invalid_First_Byte'Access));
-            S.Add_Test
-              (Caller.Create
-                 (Name & " test multi-part hash finish and verify - "
-                    & "last byte corrupted",
-                  Test_Finish_Verify_Invalid_Last_Byte'Access));
+                    & "invalid hash",
+                  Test_Finish_Verify_Invalid_Hash'Access));
          end if;
       end Add_To_Suite;
 

--- a/tests/unit_tests/src/xof_tests.ads
+++ b/tests/unit_tests/src/xof_tests.ads
@@ -25,37 +25,12 @@ package XOF_Tests is
       overriding
       procedure Set_Up (T : in out Test);
 
-      ------------------------------
-      -- Multi-Part Message Tests --
-      ------------------------------
-
-      --  These tests verify that a multi-part hashing operation with varying
-      --  part sizes produces the same result as the equivalent single-part
-      --  operation.
-
-      procedure Test_Multi_Part_1 (T : in out Test);
-      procedure Test_Multi_Part_2 (T : in out Test);
-      procedure Test_Multi_Part_31 (T : in out Test);
-      procedure Test_Multi_Part_32 (T : in out Test);
-      procedure Test_Multi_Part_33 (T : in out Test);
-      procedure Test_Multi_Part_63 (T : in out Test);
-      procedure Test_Multi_Part_64 (T : in out Test);
-      procedure Test_Multi_Part_65 (T : in out Test);
-      procedure Test_Multi_Part_127 (T : in out Test);
-      procedure Test_Multi_Part_128 (T : in out Test);
-      procedure Test_Multi_Part_129 (T : in out Test);
-
-      ----------------------
-      -- XOF Verify Tests --
-      ----------------------
-
+      procedure Test_Multi_Part_Input (T : in out Test);
+      procedure Test_Multi_Part_Output (T : in out Test);
       procedure Test_Verify_Valid_Hash (T : in out Test);
-      procedure Test_Verify_Invalid_First_Byte (T : in out Test);
-      procedure Test_Verify_Invalid_Last_Byte (T : in out Test);
-
+      procedure Test_Verify_Invalid_Hash (T : in out Test);
       procedure Test_Finish_Verify_Valid_Hash (T : in out Test);
-      procedure Test_Finish_Verify_Invalid_First_Byte (T : in out Test);
-      procedure Test_Finish_Verify_Invalid_Last_Byte (T : in out Test);
+      procedure Test_Finish_Verify_Invalid_Hash (T : in out Test);
 
       procedure Add_To_Suite (S : in out Test_Suite'Class);
 
@@ -67,7 +42,7 @@ package XOF_Tests is
 
 private
 
-   procedure Multi_Part_Test
+   procedure Multi_Part_Input_Test
      (Buffer      : Tux.Types.Byte_Array;
       Algorithm   : Tux.XOF.Algorithm_Kind;
       Part_Length : Positive)
@@ -75,5 +50,17 @@ private
      Pre => Part_Length <= Buffer'Length;
    --  Test that a multi-part hashing operation with blocks of size Part_Length
    --  produces the same result as the equivalent single-part operation.
+
+   procedure Multi_Part_Output_Test
+     (Hash           : in out Tux.Types.Byte_Array;
+      Reference_Hash : in out Tux.Types.Byte_Array;
+      Algorithm      :        Tux.XOF.Algorithm_Kind;
+      Part_Length    :        Positive)
+   with
+     Pre => (Part_Length <= Hash'Length
+             and then Hash'Length = Reference_Hash'Length);
+   --  Test that extracting the output in multiple parts with blocks of size
+   --  Part_Length produces the same result as the equivalent single-part
+   --  operation.
 
 end XOF_Tests;


### PR DESCRIPTION
The multi-part tests are now executed for part sizes ranging from 1 to 256 bytes. The "verify" unit tests also test for all possible 1-bit errors in the data being verified.

These changes improve the coverage of the tests and avoids assumptions around the algorithm's block size.